### PR TITLE
Add default tracks when present

### DIFF
--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -105,6 +105,9 @@ class MKVFile:
                 command.extend(['--tags', str(track.track_id) + ':' + track.tags])
             if not track.default_track:
                 command.extend(['--default-track', str(track.track_id) + ':0'])
+            # Add default tracks when present    
+            if track.default_track:
+                command.extend(['--default-track', str(track.track_id) + ':1'])
             if track.forced_track:
                 command.extend(['--forced-track', str(track.track_id) + ':1'])
 


### PR DESCRIPTION
I tried the following to flag a track as default and remove default flag from another track: 

mkv = pymkv.MKVFile(file.mkv)
mkv.track_tags([0, 2, 3, 4], exclusive=False) # tried this; I wanted track 1 to lose its "flag" default, but I am not sure default_track is a flag
mkv.tracks[1].default_track = False # manually adjusted default_track
mkv.tracks[2].default_track = True
# mkv.swap_tracks(track_num_1=1, track_num_2=2) # swaped ordered
mkv.mux("Testfile.mkv")

Track 2 still wasn't default when I ran this code. This was the command that was generated:
mkvmerge -o testfile.mkv --language 0:und -d 0 -A 
-S file.mkv --track-name 1:track one --language 1:eng --default-track 1:0 -D -a 1 
-S file.mkv --track-name 2:track two --language 2:eng -D -a 2 
-S file.mkv --track-name 3:track three --language 3:jpn --default-track 3:0 -D -a 3 
-S file.mkv --language 4:eng --default-track 4:0 -D -A -s 4 file.mkv

It may be difficult to read, but you see that track two has no --default_track command. I think adding the simple code below fixes this? Unless there is another way with the existing code to generate the default_track command. 
            if track.default_track:
                command.extend(['--default-track', str(track.track_id) + ':1'])

Additionally, I tried adding a new track, but the default-track command still does not populate when I mux. Let me know if I'm missing something here.