### PR TITLE
Fix missing language code

### DIFF
--- a/pymkv/ISO639_2.py
+++ b/pymkv/ISO639_2.py
@@ -3,16 +3,11 @@
 
 """ISO639-2 Three Character Language Codes"""
 
-ISO639_2 = ('und', 'aar', 'abk', 'ave', 'afr', 'aka', 'amh', 'arg', 'ara', 'asm', 'ava', 'aym', 'aze', 'azb', 'bak',
-            'bel', 'bul', 'bih', 'bis', 'bam', 'ben', 'bod', 'bre', 'bos', 'cat', 'che', 'cha', 'cos', 'cre', 'ces',
-            'chu', 'chv', 'cym', 'dan', 'deu', 'div', 'dzo', 'ewe', 'ell', 'eng', 'epo', 'spa', 'est', 'eus', 'fas',
-            'ful', 'fin', 'fij', 'fao', 'fra', 'fry', 'gle', 'gla', 'glg', 'grn', 'guj', 'glv', 'hau', 'heb', 'hin',
-            'hmo', 'hrv', 'hat', 'hun', 'hye', 'her', 'ina', 'ind', 'ile', 'ibo', 'iii', 'ipk', 'ido', 'isl', 'ita',
-            'iku', 'jpn', 'jav', 'kat', 'kon', 'kik', 'kua', 'kaz', 'kal', 'khm', 'kan', 'kor', 'kau', 'kas', 'kur',
-            'kom', 'cor', 'kir', 'lat', 'ltz', 'lug', 'lim', 'lin', 'lao', 'lit', 'lub', 'lav', 'mlg', 'mah', 'mri',
-            'mkd', 'mal', 'mon', 'mar', 'msa', 'mlt', 'mya', 'nau', 'nob', 'nde', 'nep', 'ndo', 'nld', 'nno', 'nor',
-            'nbl', 'nav', 'nya', 'oci', 'oji', 'orm', 'ori', 'oss', 'pan', 'pli', 'pol', 'pus', 'por', 'que', 'roh',
-            'run', 'ron', 'rus', 'kin', 'san', 'srd', 'snd', 'sme', 'sag', 'sin', 'slk', 'slv', 'smo', 'sna', 'som',
-            'sqi', 'srp', 'ssw', 'sot', 'sun', 'swe', 'swa', 'tam', 'tel', 'tgk', 'tha', 'tir', 'tuk', 'tgl', 'tsn',
-            'ton', 'tur', 'tso', 'tat', 'twi', 'tah', 'uig', 'ukr', 'urd', 'uzb', 'ven', 'vie', 'vol', 'wln', 'wol',
-            'xho', 'yid', 'yor', 'zha', 'zho', 'zul')
+from iso639 import languages
+
+def is_ISO639_2(language):
+  try:
+    languages.get(part2b=language)
+    return True
+  except KeyError:
+    return False

--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -13,7 +13,7 @@ import bitmath
 from pymkv.MKVTrack import MKVTrack
 from pymkv.MKVAttachment import MKVAttachment
 from pymkv.Timestamp import Timestamp
-from pymkv.ISO639_2 import ISO639_2 as LANGUAGES
+from pymkv.ISO639_2 import is_ISO639_2
 from pymkv.Verifications import verify_matroska, verify_mkvmerge
 
 
@@ -81,7 +81,7 @@ class MKVFile:
 
     @chapter_language.setter
     def chapter_language(self, language):
-        if language is not None and language not in LANGUAGES:
+        if language is not None and not is_ISO639_2(language):
             raise ValueError('not an ISO639-2 language code')
         self._chapter_language = language
 

--- a/pymkv/MKVTrack.py
+++ b/pymkv/MKVTrack.py
@@ -7,8 +7,8 @@ import json
 from os.path import expanduser, isfile
 import subprocess as sp
 
-from pymkv.ISO639_2 import ISO639_2 as LANGUAGES
 from pymkv.Verifications import verify_supported
+from pymkv.ISO639_2 import is_ISO639_2
 
 
 class MKVTrack:
@@ -92,7 +92,7 @@ class MKVTrack:
 
     @language.setter
     def language(self, language):
-        if language in LANGUAGES or language is None:
+        if language is None or is_ISO639_2(language):
             self._language = language
         else:
             raise ValueError('not an ISO639-2 language code')

--- a/pymkv/__init__.py
+++ b/pymkv/__init__.py
@@ -4,4 +4,4 @@ from .MKVFile import *
 from .Timestamp import *
 from .Verifications import *
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bitmath
+iso-639

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@
 from os.path import abspath, dirname, join
 from setuptools import setup
 
-from pymkv import __version__
-
 
 this_dir = abspath(dirname(__file__))
 with open(join(this_dir, 'README.rst'), encoding='utf-8') as file:
@@ -18,7 +16,7 @@ install_requires = [r.rstrip('\n') for r in open('requirements.txt').readlines()
 
 setup(
     name='pymkv',
-    version=__version__,
+    version='1.0.4',
     description='A Python wrapper for mkvmerge. It provides support for muxing tracks together, combining multiple '
                 'MKV files, reordering tracks, naming tracks, and other MKV related things.',
     long_description=long_description,


### PR DESCRIPTION
Fix #34.

This pull request change how to detect a valid ISO639-2 language code.

Instead of maintaining a list, it uses a list from another library (`iso-639`).

Note that `setup.py` is changed because it will try to import `iso-639` before setup finishes.