### PR TITLE
Support for empty titles in MKVFiles

### DIFF
--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -154,7 +154,7 @@ class MKVFile:
 
         output_path = expanduser(output_path)
         command = [self.mkvmerge_path, '-o', output_path]
-        if self.title:
+        if self.title is not None:
             command.extend(['--title', self.title])
         # add tracks
         for track in self.tracks:


### PR DESCRIPTION
Hello,
It don't seems to be possible to have a empty title in the output file when the input one have a title.

My solution is to replace in MKVFile.py, line 157 :
```
if self.title:
```
by

```
if self.title is not None:
```
Is it a good way to resolve this problem ?
Thanks