### PR TITLE
Do not let muxing fail silently

### DIFF
--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -260,11 +260,11 @@ class MKVFile:
                                     'property')
         output_path = expanduser(output_path)
         if silent:
-            sp.run(self.command(output_path, subprocess=True), stdout=open(devnull, 'wb'))
+            sp.run(self.command(output_path, subprocess=True), stdout=open(devnull, 'wb'), check=True)
         else:
             command = self.command(output_path)
             print('Running with command:\n"' + command + '"')
-            sp.run(self.command(output_path, subprocess=True))
+            sp.run(self.command(output_path, subprocess=True), check=True, capture_output=True)
 
     def add_file(self, file):
         """Add an MKV file into the :class:`~pymkv.MKVFile` object.


### PR DESCRIPTION
If the muxing process exits with non-zero status code, it would be useful to deal with that error. As of now it fails but the Python interpreter doesn't know it.
To give an example, tried muxing a file with a non-existing, non-user-writable output path and the process failed but the interpreter didn't catch any error, so it seemed like it worked when in fact it didn't.