### PR TITLE
Add an optional "mkvmerge_path" to MKVFile()

### DIFF
--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -79,8 +79,8 @@ class MKVFile:
         Raised if the path to mkvmerge could not be verified.
     """
 
-    def __init__(self, file_path=None, title=None):
-        self.mkvmerge_path = 'mkvmerge'
+    def __init__(self, file_path=None, title=None, mkvmerge_path='mkvmerge'):
+        self.mkvmerge_path = mkvmerge_path
         self.title = title
         self._chapters_file = None
         self._chapter_language = None
@@ -249,15 +249,7 @@ class MKVFile:
             The path to be used as the output file in the mkvmerge command.
         silent : bool, optional
             By default the mkvmerge output will be shown unless silent is True.
-
-        Raises
-        ------
-        FileNotFoundError
-            Raised if the path to mkvmerge could not be verified.
         """
-        if not verify_mkvmerge(mkvmerge_path=self.mkvmerge_path):
-            raise FileNotFoundError('mkvmerge is not at the specified path, add it there or change the mkvmerge_path '
-                                    'property')
         output_path = expanduser(output_path)
         if silent:
             sp.run(self.command(output_path, subprocess=True), stdout=open(devnull, 'wb'), check=True)

--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -72,6 +72,10 @@ class MKVFile:
     title : str, optional
         The internal title given to the :class:`~pymkv.MKVFile`. If `title` is not specified, the title of the
         pre-existing file will be used if it exists.
+    mkvmerge_path : str, optional
+        The path where pymkv looks for the mkvmerge executable. pymkv relies on the mkvmerge executable to parse
+        files. By default, it is assumed mkvmerge is in your shell's $PATH variable. If it is not, you need to set
+        *mkvmerge_path* to the executable location.
 
     Raises
     ------
@@ -92,7 +96,7 @@ class MKVFile:
         if file_path is not None and not verify_mkvmerge(mkvmerge_path=self.mkvmerge_path):
             raise FileNotFoundError('mkvmerge is not at the specified path, add it there or change the mkvmerge_path '
                                     'property')
-        if file_path is not None and verify_matroska(file_path):
+        if file_path is not None and verify_matroska(file_path, mkvmerge_path=self.mkvmerge_path):
             # add file title
             file_path = expanduser(file_path)
             info_json = json.loads(sp.check_output([self.mkvmerge_path, '-J', file_path]).decode())

--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -105,7 +105,7 @@ class MKVFile:
 
             # add tracks with info
             for track in info_json['tracks']:
-                new_track = MKVTrack(file_path, track_id=track['id'])
+                new_track = MKVTrack(file_path, track_id=track['id'], mkvmerge_path=self.mkvmerge_path)
                 if 'track_name' in track['properties']:
                     new_track.track_name = track['properties']['track_name']
                 if 'language' in track['properties']:
@@ -296,7 +296,7 @@ class MKVFile:
             Raised if `track` is not a string-like path to a track file or an :class:`~pymkv.MKVTrack`.
         """
         if isinstance(track, str):
-            self.tracks.append(MKVTrack(track))
+            self.tracks.append(MKVTrack(track), mkvmerge_path=self.mkvmerge_path)
         elif isinstance(track, MKVTrack):
             self.tracks.append(track)
         else:

--- a/pymkv/MKVTrack.py
+++ b/pymkv/MKVTrack.py
@@ -67,13 +67,15 @@ class MKVTrack:
         Determines if the track should be the default track of its type when muxed into an MKV file.
     forced_track : bool, optional
         Determines if the track should be a forced track when muxed into an MKV file.
+    mkvmerge_path : str, optional
+        The path where pymkv looks for the mkvmerge executable. pymkv relies on the mkvmerge executable to parse
+        files. By default, it is assumed mkvmerge is in your shell's $PATH variable. If it is not, you need to set
+        *mkvmerge_path* to the executable location.
 
     Attributes
     ----------
     mkvmerge_path : str
-        The path where pymkv looks for the mkvmerge executable. pymkv relies on the mkvmerge executable to parse
-        files. By default, it is assumed mkvmerge is in your shell's $PATH variable. If it is not, you need to set
-        *mkvmerge_path* to the executable location.
+        The path of the mkvmerge executable.
     track_name : str
         The name that will be given to the track when muxed into a file.
     default_track : bool
@@ -98,13 +100,13 @@ class MKVTrack:
         that are already part of an MKV file.
     """
 
-    def __init__(self, file_path, track_id=0, track_name=None, language=None, default_track=False, forced_track=False):
+    def __init__(self, file_path, track_id=0, track_name=None, language=None, default_track=False, forced_track=False, mkvmerge_path='mkvmerge'):
         # track info
         self._track_codec = None
         self._track_type = None
 
         # base
-        self.mkvmerge_path = 'mkvmerge'
+        self.mkvmerge_path = mkvmerge_path
         self._file_path = None
         self.file_path = file_path
         self._track_id = None

--- a/pymkv/MKVTrack.py
+++ b/pymkv/MKVTrack.py
@@ -146,7 +146,7 @@ class MKVTrack:
     @file_path.setter
     def file_path(self, file_path):
         file_path = expanduser(file_path)
-        if not verify_supported(file_path):
+        if not verify_supported(file_path, mkvmerge_path=self.mkvmerge_path):
             raise ValueError('"{}" is not a supported file')
         self._file_path = file_path
         self.track_id = 0


### PR DESCRIPTION
Added an optional "mkvmerge_path" keyword argument to MKVFile's constructor, so if someone wants to use a custom one, now they can, and removed the second verify_mkvmerge on mux(), because it is already checked in __init__ so if the path can't be found, an error is already thrown by that method.